### PR TITLE
Develop gecheckt voor v1.0.0

### DIFF
--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -1,0 +1,32 @@
+---
+layout: page-with-side-nav
+title: Haal Centraal Reisdocumenten bevragen
+---
+# Releasenotes Haal-Centraal-Reisdocumenten-Bevragen
+
+## Versie 1.0.0
+
+Alhoewel er nog geen eerdere officiële versie van de Haal-Centraal-Reisdocumenten-bevragen API als release is uitgebracht is de specificatie het afgelopen jaar redelijk stabiel geweest.
+Voor het uitbrengen van release v1.0.0 is besloten om de nieuwe inzichten die het afgelopen jaar zijn opgedaan op te nemen. Hier een globaal (en niet limitatief) overzicht van wijzigingen die doorgevoerd zijn voordat v1.0.0 is uitgebracht. Enkele van deze wijzigingen zijn breaking ten opzichte van v0.9.0 .
+
+We bieden nu ook SDK's aan met gegenereerde [plumbing-code](./code).
+Daarnaast bieden we een[postman-collectie](./test) t.b.v. testen aan.
+
+### Openapi.yaml :
+
+- Base-url aangepast. (Breaking)
+- Alle descriptions zijn omgezet naar markdown.
+- Bij property reisdocumentnummer is de maxLength weggehaald.
+- OperationId's zijn aangepast. (Breaking)
+- Fields-parameter is toegevoegd
+- Titles en descriptions bij de booleans van ReisdocumentInOnderzoek zijn verwijderd.
+- Enkele namen van schema-componenten zijn aangepast vanwege consistentie met andere Haal-Centraal API's
+  - Hal-componenten die alleen _links bevatten zijn omgenoemd van xxxHal naar xxxHalBasis
+  - AanduidingInhoudingVermissingReisdocument_enum --> AanduidingInhoudingVermissingReisdocumentEnum
+  - Reisdocument_links --> ReisdocumentLinks
+
+
+### Features:
+
+- fields_extensie.feature is toegevoegd
+- in_onderzoe.feature is toegevoegd.

--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -18,7 +18,6 @@ Daarnaast bieden we een[postman-collectie](./test) t.b.v. testen aan.
 - Alle descriptions zijn omgezet naar markdown.
 - Bij property reisdocumentnummer is de maxLength weggehaald.
 - OperationId's zijn aangepast. (Breaking)
-- Fields-parameter is toegevoegd
 - Titles en descriptions bij de booleans van ReisdocumentInOnderzoek zijn verwijderd.
 - Enkele namen van schema-componenten zijn aangepast vanwege consistentie met andere Haal-Centraal API's
   - Hal-componenten die alleen _links bevatten zijn omgenoemd van xxxHal naar xxxHalBasis

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -5,8 +5,9 @@ servers:
     url: https://www.haalcentraal.nl/haalcentraal/api/brp
 info:
   title: Reisdocumenten
-  description: "API voor het ontsluiten van gegevens van reisdocumenten uit de GBA en RNI."
-  version: "0.9.0"
+  description: |
+                API voor het ontsluiten van gegevens van reisdocumenten uit de GBA en RNI.
+  version: "1.0.0"
   contact:
     url: https://github.com/VNG-Realisatie/Haal-Centraal-Reisdocumenten-bevragen
   license:
@@ -27,7 +28,7 @@ paths:
           required: true
           schema:
             type: string
-            maxLength: 9
+            maxlength: 9
       responses:
         '200':
           description: "Zoekactie geslaagd"
@@ -39,7 +40,7 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ReisdocumentHal'
+                $ref: '#/components/schemas/ReisdocumentHalBasis'
         '400':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/400"
         '401':
@@ -78,7 +79,6 @@ components:
           title: "Reisdocumentnummer"
           description: |
                         Het nummer van het Nederlandse reisdocument.
-          maxLength: 9
           example: "546376728"
         autoriteitAfgifte:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
@@ -97,7 +97,7 @@ components:
                         Een aanduiding die aangeeft dat gegevens wel of niet verstrektmogen worden. Indien true: op verzoek van deze persoon is het verstrekken van gegevens over deze persoon aan bepaalde derden niet toegestaan.
         inOnderzoek:
           $ref: "#/components/schemas/ReisdocumentInOnderzoek"
-    ReisdocumentHal:
+    ReisdocumentHalBasis:
       allOf:
         - $ref: '#/components/schemas/Reisdocument'
         - properties:

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -28,7 +28,7 @@ paths:
           required: true
           schema:
             type: string
-            maxlength: 9
+            maxLength: 9
       responses:
         '200':
           description: "Zoekactie geslaagd"

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -40,7 +40,7 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ReisdocumentHalBasis'
+                $ref: '#/components/schemas/ReisdocumentHal'
         '400':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/400"
         '401':
@@ -76,7 +76,6 @@ components:
           $ref: "#/components/schemas/AanduidingInhoudingVermissingReisdocumentEnum"
         reisdocumentnummer:
           type: "string"
-          title: "Reisdocumentnummer"
           description: |
                         Het nummer van het Nederlandse reisdocument.
           example: "546376728"
@@ -94,10 +93,10 @@ components:
           type: "boolean"
           title: "Indicatie geheim"
           description: |
-                        Een aanduiding die aangeeft dat gegevens wel of niet verstrektmogen worden. Indien true: op verzoek van deze persoon is het verstrekken van gegevens over deze persoon aan bepaalde derden niet toegestaan.
+                        Een aanduiding die aangeeft dat gegevens wel of niet verstrekt mogen worden. Indien true: op verzoek van deze persoon is het verstrekken van gegevens over deze persoon aan bepaalde derden niet toegestaan.
         inOnderzoek:
           $ref: "#/components/schemas/ReisdocumentInOnderzoek"
-    ReisdocumentHalBasis:
+    ReisdocumentHal:
       allOf:
         - $ref: '#/components/schemas/Reisdocument'
         - properties:


### PR DESCRIPTION
Een paar kleine wijzigingen n.a.v. het doornemen van de openapi.yaml voor versie 1.0.0 :
- versienummer weer naar 1.0.0 gezet
- maxLength en title verwijderd bij property reisdocumentnummer
- componentnaam ReisdocumentnummerHal aangepast naar ReisdocumentHalBasis (bevat alleen Links)
- tikfout description geheimhoudingPersoonsgegevens

Releasenotes toegevoegd. 
Voorzover ik kan zien is het aanpassen van de Base-URL breaking en is het aanpassen van de OperationId's breaking (Daar twijfel ik.  Melvin? ). 