### PR TITLE
Gba versie reisdocumenten moet array zijn

### DIFF
--- a/specificatie/gba-genereervariant/openapi.json
+++ b/specificatie/gba-genereervariant/openapi.json
@@ -332,7 +332,7 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/GbaReisdocument"
+                  "$ref" : "#/components/schemas/GbaReisdocumentenResponse"
                 }
               }
             }
@@ -709,6 +709,17 @@
         "properties" : {
           "burgerservicenummer" : {
             "$ref" : "#/components/schemas/Burgerservicenummer"
+          }
+        }
+      },
+      "GbaReisdocumentenResponse" : {
+        "type" : "object",
+        "properties" : {
+          "reisdocumenten" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/GbaReisdocument"
+            }
           }
         }
       },

--- a/specificatie/gba-genereervariant/openapi.yaml
+++ b/specificatie/gba-genereervariant/openapi.yaml
@@ -248,7 +248,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GbaReisdocument'
+                $ref: '#/components/schemas/GbaReisdocumentenResponse'
         "400":
           description: Bad Request
           headers:
@@ -525,6 +525,13 @@ components:
       properties:
         burgerservicenummer:
           $ref: '#/components/schemas/Burgerservicenummer'
+    GbaReisdocumentenResponse:
+      type: object
+      properties:
+        reisdocumenten:
+          type: array
+          items:
+            $ref: '#/components/schemas/GbaReisdocument'
     Waardetabel:
       type: object
       properties:

--- a/specificatie/gba-openapi.yaml
+++ b/specificatie/gba-openapi.yaml
@@ -94,7 +94,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'reisdocument.yaml#/components/schemas/GbaReisdocument'
+                $ref: 'reisdocument.yaml#/components/schemas/GbaReisdocumentenResponse'
         '400':
           $ref: 'common.yaml#/components/responses/400'
         '401':

--- a/specificatie/reisdocument.yaml
+++ b/specificatie/reisdocument.yaml
@@ -86,4 +86,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ReisdocumentUitgebreid'
-
+    GbaReisdocumentenResponse:
+      type: object
+      properties:
+        reisdocumenten:
+          type: array
+          items:
+            $ref: '#/components/schemas/GbaReisdocument'


### PR DESCRIPTION
De Gba versie response voor /reisdocumenten (op burgerservicenummer) is nu reisdocument object, maar moet array van reisdocumenten zijn. De response van de proxy op /reisdocumenten (op burgerservicenummer) is immers ook een array. Een persoon kan tegelijkertijd meerdere geldige reisdocumenten hebben.